### PR TITLE
bugfix: push module dependency to correct version

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -7,4 +7,4 @@ summary 'Configures MySQL for security hardening'
 description 'Configures MySQL for security hardening'
 project_page 'https://github.com/TelekomLabs/puppet-mysql-hardening'
 
-dependency 'hardening/hardening_stdlib', '>=1.0.0 <2.0.0'
+dependency 'hardening/hardening_stdlib', '>=0.0.0 <1.0.0'


### PR DESCRIPTION
hardening/hardening_stdlib isn't released for 1.x.x yet, but only on 0.x.x, so adjust the dependency

Signed-off-by: Dominik Richter dominik.richter@gmail.com
