### PR TITLE
Porting to use the new mysql::deepmerge function

### DIFF
--- a/manifests/puppetlabs_override.pp
+++ b/manifests/puppetlabs_override.pp
@@ -15,7 +15,7 @@
 #
 class mysql_hardening::puppetlabs_override inherits ::mysql::server::config {
   # merges the final set of options
-  $options = mysql_deepmerge( $::mysql::server::options, $::mysql_hardening::puppetlabs::new_options )
+  $options = mysql::deepmerge( $::mysql::server::options, $::mysql_hardening::puppetlabs::new_options )
   # write the new template
   if defined(File['mysql-config-file']) {
     $mysql_config_filename = 'mysql-config-file'


### PR DESCRIPTION
The mysql_deepmerge function was flawed and will crash on Puppet version 5.5.7. This changes your code to use the new version of the function, which does not have this flaw. See https://tickets.puppetlabs.com/browse/MODULES-8193 for more details.